### PR TITLE
Refactor cache handling, tests and add docstrings

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-POKEAPI_BERRY_URL=https://pokeapi.co/api/v2/berry/
-CACHE_TTL=120
-CACHE_MAXSIZE=100
-PORT=8080

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ Create a `.env` file in the root directory of your project to store environment 
 ```makefile
 POKEAPI_BERRY_URL=https://pokeapi.co/api/v2/berry/ # URL for resource of pokeapi
 CACHE_TTL=120  # Cache TTL in seconds
-CACHE_MAXSIZE=100  # Max cache size
 PORT=8080 # To open port 8080
+REDIS_HOSTNAME=your-redis-hostname # Hostname for connection of redis redis cache service
+REDIS_PORT=your-redis-port # Port for connection of redis redis cache service
+REDIS_PASSWORD=your-redis-pw # Password for connection of redis cache service
 ```
 
 ### 4. Running the Application Locally

--- a/app/cache/cache_handler.py
+++ b/app/cache/cache_handler.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import redis
 import json

--- a/app/cache/cache_handler.py
+++ b/app/cache/cache_handler.py
@@ -1,7 +1,33 @@
 import os
-from cachetools import TTLCache
+import redis
+import json
 
-CACHE_TTL = int(os.getenv("CACHE_TTL"))
-CACHE_MAXSIZE = int(os.getenv("CACHE_MAXSIZE"))
+class RedisCacheHandler:
+    def __init__(self):
+        self.host = os.getenv("REDIS_HOSTNAME")
+        self.port = int(os.getenv("REDIS_PORT"))
+        self.password = os.getenv("REDIS_PASSWORD")
+        self.ttl = int(os.getenv("CACHE_TTL"))
 
-cache = TTLCache(maxsize=CACHE_MAXSIZE, ttl=CACHE_TTL)
+        self.client = redis.StrictRedis(
+            host=self.host,
+            port=self.port,
+            password=self.password,
+            decode_responses=True
+        )
+
+    def set(self, key, value):
+        """Set serialized value in Redis with a TTL."""
+        serialized_value = json.dumps(value)
+        self.client.setex(key, self.ttl, serialized_value)
+
+    def get(self, key):
+        """Get and deserialize value from Redis by key."""
+        data = self.client.get(key)
+        if data:
+            return json.loads(data)
+        return None
+
+    def clear(self):
+        """Clear all data in Redis."""
+        self.client.flushdb()

--- a/app/controllers/berry_controller.py
+++ b/app/controllers/berry_controller.py
@@ -11,13 +11,13 @@ router = APIRouter()
 async def all_berry_stats():
     return await get_berry_stats()
 
-@router.get("/histogram")
+@router.get("/histogram", responses={200: {"content": {"image/png": {}}}})
 async def generate_histogram():
     stats = await get_berry_stats()
     
     growth_times = []
     for growth_time, frequency in stats['frequency_growth_time'].items():
-        growth_times.extend([growth_time] * frequency)
+        growth_times.extend([int(growth_time)] * frequency)
     
     if growth_times:
         fig, ax = plt.subplots()

--- a/app/controllers/berry_controller.py
+++ b/app/controllers/berry_controller.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import io
 import matplotlib.pyplot as plt
 from fastapi.responses import StreamingResponse, HTMLResponse
@@ -9,14 +10,35 @@ router = APIRouter()
 
 @router.get("/allBerryStats", response_model=BerryStatsResponseModel)
 async def all_berry_stats():
+    """
+    Fetch all berry growth statistics.
+
+    This endpoint fetches and returns the berry growth statistics such as minimum, 
+    maximum, median, mean, variance, and the frequency distribution of growth times.
+
+    Returns:
+        BerryStatsResponseModel: A JSON response containing the berry growth statistics.
+    """
     return await get_berry_stats()
 
 @router.get("/histogram", responses={200: {"content": {"image/png": {}}}})
 async def generate_histogram():
+    """
+    Generate a histogram image of berry growth times and return it as a PNG image.
+    
+    Fetches the berry growth statistics, processes the frequency of growth times, and uses matplotlib
+    to create a histogram. If valid growth times are available, the plot is generated and returned.
+    Otherwise, an error message is provided in the response.
+    
+    Returns:
+        StreamingResponse: A PNG image of the histogram if growth times are available,
+        or an error message if no valid growth times exist.
+    """
     stats = await get_berry_stats()
     
     growth_times = []
-    for growth_time, frequency in stats['frequency_growth_time'].items():
+    
+    for growth_time, frequency in stats.frequency_growth_time.items():
         growth_times.extend([int(growth_time)] * frequency)
     
     if growth_times:
@@ -41,6 +63,15 @@ async def generate_histogram():
 
 @router.get("/view-histogram", response_class=HTMLResponse)
 async def view_histogram():
+    """
+    View the berry growth time histogram in HTML.
+
+    This endpoint displays the histogram of berry growth times in a simple HTML page 
+    by embedding the PNG image generated from the `/histogram` endpoint.
+
+    Returns:
+        HTMLResponse: An HTML page displaying the histogram image.
+    """
     html_content = """
     <html>
         <head>

--- a/app/controllers/root_controller.py
+++ b/app/controllers/root_controller.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from fastapi import APIRouter
 from fastapi.responses import HTMLResponse
 
@@ -5,6 +6,17 @@ router = APIRouter()
 
 @router.get("/", response_class=HTMLResponse)
 async def root():
+    """
+    Root endpoint of the PokeAPI Berries Statistics API.
+
+    This endpoint renders a welcome HTML page that provides an overview of the API 
+    and offers links to the main endpoints. The page includes a title, description, 
+    and navigation to access the API documentation, berry growth statistics, and 
+    berry growth time histogram.
+
+    Returns:
+        HTMLResponse: A simple HTML page displaying the welcome message and links to the API endpoints.
+    """
     html_content = """
     <html>
         <head>

--- a/app/data_providers/pokeapi_provider.py
+++ b/app/data_providers/pokeapi_provider.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import requests
 import logging
@@ -9,6 +10,22 @@ logger = logging.getLogger(__name__)
 POKEAPI_BERRY_URL = os.getenv("POKEAPI_BERRY_URL")
 
 async def fetch_all_berries():
+    """
+    Fetch all berries data from the PokeAPI.
+
+    This function fetches a list of all berries available from the PokeAPI by 
+    sending a request to the provided POKEAPI_BERRY_URL. For each berry, it fetches 
+    additional details, such as the berry's name and growth time, and stores them in a list.
+
+    Returns:
+        list: A list of dictionaries containing each berry's name and growth time.
+        In case of errors, it returns an empty list.
+
+    Error Handling:
+        - If a `RequestException` occurs (e.g., network error, invalid URL), logs the error and returns an empty list.
+        - If a `ValueError` occurs (e.g., parsing issues), logs the error and returns an empty list.
+        - If any other unexpected error occurs, logs the error and returns an empty list.
+    """
     try:
         response = requests.get(POKEAPI_BERRY_URL)
         response.raise_for_status()

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import uvicorn
 from fastapi import FastAPI

--- a/app/models/berry_models.py
+++ b/app/models/berry_models.py
@@ -1,17 +1,17 @@
-from pydantic import BaseModel
-from typing import List, Dict
+from pydantic import BaseModel, ConfigDict
+from typing import List, Dict, Optional
 
 class BerryStatsResponseModel(BaseModel):
-    berries_names: List[str]
-    min_growth_time: int
-    median_growth_time: float
-    max_growth_time: int
-    variance_growth_time: float
-    mean_growth_time: float
-    frequency_growth_time: Dict[int, int]
-
-    class Config:
-        schema_extra = {
+    berries_names: List[str] = []
+    min_growth_time: Optional[int] = None
+    median_growth_time: Optional[float] = None
+    max_growth_time: Optional[int] = None
+    variance_growth_time: Optional[float] = None
+    mean_growth_time: Optional[float] = None
+    frequency_growth_time: Dict[int, int] = {}
+    
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "berries_names": ["cheri", "pecha"],
                 "min_growth_time": 2,
@@ -19,6 +19,7 @@ class BerryStatsResponseModel(BaseModel):
                 "max_growth_time": 8,
                 "variance_growth_time": 1.3,
                 "mean_growth_time": 5.2,
-                "frequency_growth_time": {2: 3, 4: 5, 8: 2}
+                "frequency_growth_time": {"2": 3, "4": 5, "8": 2}
             }
         }
+    )

--- a/app/models/berry_models.py
+++ b/app/models/berry_models.py
@@ -1,7 +1,21 @@
+# -*- coding: utf-8 -*-
 from pydantic import BaseModel, ConfigDict
 from typing import List, Dict, Optional
 
 class BerryStatsResponseModel(BaseModel):
+    """
+    Data model for representing statistics of berry growth times.
+
+    Attributes:
+        berries_names (List[str]): A list of berry names.
+        min_growth_time (Optional[int]): The minimum growth time among the berries.
+        median_growth_time (Optional[float]): The median growth time.
+        max_growth_time (Optional[int]): The maximum growth time.
+        variance_growth_time (Optional[float]): The variance of the growth times.
+        mean_growth_time (Optional[float]): The mean of the growth times.
+        frequency_growth_time (Dict[int, int]): A dictionary mapping growth times to the frequency 
+            of berries having that growth time.
+    """
     berries_names: List[str] = []
     min_growth_time: Optional[int] = None
     median_growth_time: Optional[float] = None

--- a/app/services/berry_service.py
+++ b/app/services/berry_service.py
@@ -1,15 +1,18 @@
 import logging
 import statistics
 from app.data_providers.pokeapi_provider import fetch_all_berries
-from app.cache.cache_handler import cache
+from app.cache.cache_handler import RedisCacheHandler
 
+cache = RedisCacheHandler()
 logging.basicConfig(level=logging.INFO)
 
 async def get_berry_stats():
-    if 'berry_stats' in cache:
-        logging.info("Returning from cache")
-        return cache['berry_stats']
+    cached_data = cache.get("berry_stats")
+    if cached_data:
+        logging.info("Fetching data from cache.")
+        return cached_data
     
+    logging.info("Fetching data from PokeAPI.")
     berries = await fetch_all_berries()
     growth_times = [berry['growth_time'] for berry in berries if 'growth_time' in berry]
     
@@ -20,8 +23,9 @@ async def get_berry_stats():
         "max_growth_time": int(max(growth_times)) if growth_times else None,
         "variance_growth_time": float(statistics.variance(growth_times)) if len(growth_times) > 1 else None,
         "mean_growth_time": float(statistics.mean(growth_times)) if growth_times else None,
-        "frequency_growth_time": {int(x): int(growth_times.count(x)) for x in set(growth_times)}
+        "frequency_growth_time": {str(x): int(growth_times.count(x)) for x in set(growth_times)}
     }
 
-    cache['berry_stats'] = stats
+    cache.set("berry_stats", stats)
+    logging.info("Storing data in cache.")
     return stats

--- a/app/services/berry_service.py
+++ b/app/services/berry_service.py
@@ -1,31 +1,46 @@
+# -*- coding: utf-8 -*-
 import logging
 import statistics
 from app.data_providers.pokeapi_provider import fetch_all_berries
 from app.cache.cache_handler import RedisCacheHandler
+from app.models.berry_models import BerryStatsResponseModel
 
 cache = RedisCacheHandler()
 logging.basicConfig(level=logging.INFO)
 
 async def get_berry_stats():
+    """
+    Fetch berry growth statistics, either from the cache or by retrieving data from PokeAPI.
+
+    This function first checks if the berry statistics are available in the Redis cache.
+    If cached data exists, it is returned. Otherwise, it fetches the data from PokeAPI, computes
+    various statistics on berry growth times (like min, median, max, variance, mean, and frequency), 
+    stores the results in Redis for caching, and then returns the computed statistics using the 
+    BerryStatsResponseModel.
+
+    Returns:
+        BerryStatsResponseModel: A Pydantic model containing berry names and their growth statistics.
+    """
     cached_data = cache.get("berry_stats")
     if cached_data:
         logging.info("Fetching data from cache.")
-        return cached_data
+        return BerryStatsResponseModel(**cached_data)
     
     logging.info("Fetching data from PokeAPI.")
     berries = await fetch_all_berries()
     growth_times = [berry['growth_time'] for berry in berries if 'growth_time' in berry]
     
-    stats = {
-        "berries_names": [berry['name'] for berry in berries],
-        "min_growth_time": int(min(growth_times)) if growth_times else None,
-        "median_growth_time": float(statistics.median(growth_times)) if growth_times else None,
-        "max_growth_time": int(max(growth_times)) if growth_times else None,
-        "variance_growth_time": float(statistics.variance(growth_times)) if len(growth_times) > 1 else None,
-        "mean_growth_time": float(statistics.mean(growth_times)) if growth_times else None,
-        "frequency_growth_time": {str(x): int(growth_times.count(x)) for x in set(growth_times)}
-    }
-
-    cache.set("berry_stats", stats)
+    stats = BerryStatsResponseModel(
+        berries_names=[berry['name'] for berry in berries],
+        min_growth_time=int(min(growth_times)) if growth_times else None,
+        median_growth_time=float(statistics.median(growth_times)) if growth_times else None,
+        max_growth_time=int(max(growth_times)) if growth_times else None,
+        variance_growth_time=float(statistics.variance(growth_times)) if len(growth_times) > 1 else None,
+        mean_growth_time=float(statistics.mean(growth_times)) if growth_times else None,
+        frequency_growth_time={str(x): int(growth_times.count(x)) for x in set(growth_times)}
+    )
+    
+    cache.set("berry_stats", stats.model_dump())
     logging.info("Storing data in cache.")
+    
     return stats

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-fastapi==0.100.1
-uvicorn==0.25.0
-requests==2.31.0
 cachetools==5.3.1
+fastapi==0.100.1
 matplotlib==3.9.2
-pytest==8.3.2
 pytest-asyncio==0.23.8
+pytest==8.3.2
 python-dotenv==1.0.0
+redis==4.6.0
+requests==2.31.0
+uvicorn==0.25.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 from fastapi.testclient import TestClient
 from app.main import app

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,4 @@
-
+# -*- coding: utf-8 -*-
 from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock
 from app.main import app
@@ -8,6 +8,16 @@ client = TestClient(app)
 mock_cache = MagicMock(spec=RedisCacheHandler)
 
 def test_all_berry_stats():
+    """
+    Test the '/allBerryStats' endpoint for a valid response.
+    
+    This test mocks the `get_berry_stats` function to return a predefined set of
+    berry statistics, and verifies that the correct values are returned by the API.
+    
+    It also checks for the presence of keys like 'berries_names', 'min_growth_time',
+    'median_growth_time', 'max_growth_time', 'variance_growth_time', 'mean_growth_time', 
+    and 'frequency_growth_time' in the response, and asserts the values are as expected.
+    """
     with patch('app.cache.cache_handler.RedisCacheHandler', return_value=mock_cache):
         mock_cache.clear()
 
@@ -46,6 +56,13 @@ def test_all_berry_stats():
         assert data["frequency_growth_time"] == {"3": 1, "7": 1}
 
 def test_all_berry_stats_empty():
+    """
+    Test the '/allBerryStats' endpoint when no berry data is available.
+
+    This test mocks the `get_berry_stats` function to return an empty dataset and
+    verifies that the API responds with no berry data, and 'min_growth_time', 'max_growth_time',
+    and 'mean_growth_time' are set to `None`.
+    """
     with patch('app.cache.cache_handler.RedisCacheHandler', return_value=mock_cache):
         mock_cache.clear()
         
@@ -66,5 +83,11 @@ def test_all_berry_stats_empty():
         assert data["mean_growth_time"] is None
 
 def test_invalid_url():
+    """
+    Test that the API correctly returns a 404 error for an invalid endpoint.
+
+    This test sends a GET request to an invalid endpoint (`/invalidEndpoint`) 
+    and verifies that the API returns a 404 status code.
+    """
     response = client.get("/invalidEndpoint")
     assert response.status_code == 404

--- a/tests/test_berry_service.py
+++ b/tests/test_berry_service.py
@@ -1,44 +1,51 @@
 import pytest
-from app.services.berry_service import get_berry_stats
-from app.cache.cache_handler import cache
 from unittest.mock import patch, AsyncMock
+from app.services.berry_service import get_berry_stats
 
 @pytest.mark.asyncio
 async def test_get_berry_stats_valid_data():
-    cache.clear()
-    
-    mock_berries = [
-        {'name': 'cheri', 'growth_time': 3},
-        {'name': 'pecha', 'growth_time': 5},
-        {'name': 'oran', 'growth_time': 7},
-    ]
-    
-    with patch('app.services.berry_service.fetch_all_berries', new=AsyncMock(return_value=mock_berries)) as mock_fetch:
-        stats = await get_berry_stats()
+    with patch('app.cache.cache_handler.RedisCacheHandler.get', return_value=None), \
+        patch('app.cache.cache_handler.RedisCacheHandler.set', return_value=None) as mock_cache_set:
         
-        mock_fetch.assert_called_once()
-    
-    assert stats["berries_names"] == ["cheri", "pecha", "oran"]
-    assert stats["min_growth_time"] == 3
-    assert stats["median_growth_time"] == 5
-    assert stats["max_growth_time"] == 7
+        mock_berries = [
+            {'name': 'cheri', 'growth_time': 3},
+            {'name': 'pecha', 'growth_time': 5},
+            {'name': 'oran', 'growth_time': 7},
+        ]
+        
+        with patch('app.services.berry_service.fetch_all_berries', new=AsyncMock(return_value=mock_berries)) as mock_fetch:
+            stats = await get_berry_stats()
+            
+            mock_fetch.assert_called_once()
+            mock_cache_set.assert_called_once_with("berry_stats", stats)
+        
+        assert stats["berries_names"] == ["cheri", "pecha", "oran"]
+        assert stats["min_growth_time"] == 3
+        assert stats["median_growth_time"] == 5
+        assert stats["max_growth_time"] == 7
+        assert stats["variance_growth_time"] == 4.0
+        assert stats["mean_growth_time"] == 5.0
+        assert stats["frequency_growth_time"] == {"3": 1, "5": 1, "7": 1}
+
 
 @pytest.mark.asyncio
 async def test_get_berry_stats_no_data():
-    cache.clear()
-    
-    mock_berries = []
-    with patch('app.services.berry_service.fetch_all_berries', new=AsyncMock(return_value=mock_berries)) as mock_fetch:
-        stats = await get_berry_stats()
+    with patch('app.cache.cache_handler.RedisCacheHandler.get', return_value=None), \
+        patch('app.cache.cache_handler.RedisCacheHandler.set', return_value=None):
         
-        mock_fetch.assert_called_once()
-    
-    assert stats["berries_names"] == []
-    assert stats["min_growth_time"] is None
-    assert stats["max_growth_time"] is None
-    assert stats["mean_growth_time"] is None
-    assert stats["variance_growth_time"] is None
-    assert stats["frequency_growth_time"] == {}
+        mock_berries = []
+        with patch('app.services.berry_service.fetch_all_berries', new=AsyncMock(return_value=mock_berries)) as mock_fetch:
+            stats = await get_berry_stats()
+            
+            mock_fetch.assert_called_once()
+            
+        assert stats["berries_names"] == []
+        assert stats["min_growth_time"] is None
+        assert stats["max_growth_time"] is None
+        assert stats["mean_growth_time"] is None
+        assert stats["variance_growth_time"] is None
+        assert stats["frequency_growth_time"] == {}
+
 
 @pytest.mark.asyncio
 async def test_get_berry_stats_with_cache():
@@ -48,9 +55,10 @@ async def test_get_berry_stats_with_cache():
         "max_growth_time": 1,
         "mean_growth_time": 1.0,
         "variance_growth_time": 0.0,
-        "frequency_growth_time": {1: 1}
+        "frequency_growth_time": {"1": 1}
     }
-    cache['berry_stats'] = cached_stats
     
-    stats = await get_berry_stats()
+    with patch('app.cache.cache_handler.RedisCacheHandler.get', return_value=cached_stats):
+        stats = await get_berry_stats()
+        
     assert stats == cached_stats

--- a/tests/test_berry_service.py
+++ b/tests/test_berry_service.py
@@ -2,91 +2,72 @@
 import pytest
 from unittest.mock import patch, AsyncMock
 from app.services.berry_service import get_berry_stats
+from app.models.berry_models import BerryStatsResponseModel
 
 @pytest.mark.asyncio
 async def test_get_berry_stats_valid_data():
     """
     Test the `get_berry_stats` function when valid berry data is fetched from PokeAPI.
-
-    This test mocks the cache and PokeAPI response to simulate valid berry data.
-    It ensures that:
-    - `fetch_all_berries` is called once.
-    - Cache is updated with the correct statistics.
-    - The statistics returned include correct values for berry names, growth times,
-    variance, mean, and frequency growth times.
     """
     with patch('app.cache.cache_handler.RedisCacheHandler.get', return_value=None), \
         patch('app.cache.cache_handler.RedisCacheHandler.set', return_value=None) as mock_cache_set:
-        
+
         mock_berries = [
             {'name': 'cheri', 'growth_time': 3},
             {'name': 'pecha', 'growth_time': 5},
             {'name': 'oran', 'growth_time': 7},
         ]
-        
+
         with patch('app.services.berry_service.fetch_all_berries', new=AsyncMock(return_value=mock_berries)) as mock_fetch:
             stats = await get_berry_stats()
-            
-            mock_fetch.assert_called_once()
-            mock_cache_set.assert_called_once_with("berry_stats", stats)
-        
-        assert stats["berries_names"] == ["cheri", "pecha", "oran"]
-        assert stats["min_growth_time"] == 3
-        assert stats["median_growth_time"] == 5
-        assert stats["max_growth_time"] == 7
-        assert stats["variance_growth_time"] == 4.0
-        assert stats["mean_growth_time"] == 5.0
-        assert stats["frequency_growth_time"] == {"3": 1, "5": 1, "7": 1}
 
+            mock_fetch.assert_called_once()
+            mock_cache_set.assert_called_once_with("berry_stats", stats.model_dump())  # Convert Pydantic model to dict
+        
+        assert stats.berries_names == ["cheri", "pecha", "oran"]
+        assert stats.min_growth_time == 3
+        assert stats.median_growth_time == 5
+        assert stats.max_growth_time == 7
+        assert stats.variance_growth_time == 4.0
+        assert stats.mean_growth_time == 5.0
+        assert stats.frequency_growth_time == {3: 1, 5: 1, 7: 1}
 
 @pytest.mark.asyncio
 async def test_get_berry_stats_no_data():
     """
     Test the `get_berry_stats` function when no berry data is available from PokeAPI.
-
-    This test mocks the cache and simulates an empty response from PokeAPI.
-    It ensures that:
-    - `fetch_all_berries` is called once.
-    - The statistics returned have no berry names, and all growth time values are set to None.
-    - Frequency growth time is an empty dictionary.
     """
     with patch('app.cache.cache_handler.RedisCacheHandler.get', return_value=None), \
         patch('app.cache.cache_handler.RedisCacheHandler.set', return_value=None):
-        
+
         mock_berries = []
         with patch('app.services.berry_service.fetch_all_berries', new=AsyncMock(return_value=mock_berries)) as mock_fetch:
             stats = await get_berry_stats()
             
             mock_fetch.assert_called_once()
             
-        assert stats["berries_names"] == []
-        assert stats["min_growth_time"] is None
-        assert stats["max_growth_time"] is None
-        assert stats["mean_growth_time"] is None
-        assert stats["variance_growth_time"] is None
-        assert stats["frequency_growth_time"] == {}
-
+        assert stats.berries_names == []
+        assert stats.min_growth_time is None
+        assert stats.max_growth_time is None
+        assert stats.mean_growth_time is None
+        assert stats.variance_growth_time is None
+        assert stats.frequency_growth_time == {}
 
 @pytest.mark.asyncio
 async def test_get_berry_stats_with_cache():
     """
     Test the `get_berry_stats` function when berry data is fetched from cache.
-
-    This test mocks the cache to simulate a scenario where berry statistics are retrieved from the cache.
-    It ensures that:
-    - The function returns the cached data directly without calling `fetch_all_berries`.
-    - The returned statistics match the cached data.
     """
-    cached_stats = {
-        "berries_names": ["cached_cheri"],
-        "min_growth_time": 1,
-        "max_growth_time": 1,
-        "mean_growth_time": 1.0,
-        "variance_growth_time": 0.0,
-        "frequency_growth_time": {"1": 1}
-    }
+    cached_stats = BerryStatsResponseModel(
+        berries_names=["cached_cheri"],
+        min_growth_time=1,
+        max_growth_time=1,
+        mean_growth_time=1.0,
+        variance_growth_time=0.0,
+        frequency_growth_time={1: 1}
+    )
     
-    with patch('app.cache.cache_handler.RedisCacheHandler.get', return_value=cached_stats):
+    with patch('app.cache.cache_handler.RedisCacheHandler.get', return_value=cached_stats.dict()):
         stats = await get_berry_stats()
-        
+    
     assert stats == cached_stats

--- a/tests/test_berry_service.py
+++ b/tests/test_berry_service.py
@@ -1,9 +1,20 @@
+# -*- coding: utf-8 -*-
 import pytest
 from unittest.mock import patch, AsyncMock
 from app.services.berry_service import get_berry_stats
 
 @pytest.mark.asyncio
 async def test_get_berry_stats_valid_data():
+    """
+    Test the `get_berry_stats` function when valid berry data is fetched from PokeAPI.
+
+    This test mocks the cache and PokeAPI response to simulate valid berry data.
+    It ensures that:
+    - `fetch_all_berries` is called once.
+    - Cache is updated with the correct statistics.
+    - The statistics returned include correct values for berry names, growth times,
+    variance, mean, and frequency growth times.
+    """
     with patch('app.cache.cache_handler.RedisCacheHandler.get', return_value=None), \
         patch('app.cache.cache_handler.RedisCacheHandler.set', return_value=None) as mock_cache_set:
         
@@ -30,6 +41,15 @@ async def test_get_berry_stats_valid_data():
 
 @pytest.mark.asyncio
 async def test_get_berry_stats_no_data():
+    """
+    Test the `get_berry_stats` function when no berry data is available from PokeAPI.
+
+    This test mocks the cache and simulates an empty response from PokeAPI.
+    It ensures that:
+    - `fetch_all_berries` is called once.
+    - The statistics returned have no berry names, and all growth time values are set to None.
+    - Frequency growth time is an empty dictionary.
+    """
     with patch('app.cache.cache_handler.RedisCacheHandler.get', return_value=None), \
         patch('app.cache.cache_handler.RedisCacheHandler.set', return_value=None):
         
@@ -49,6 +69,14 @@ async def test_get_berry_stats_no_data():
 
 @pytest.mark.asyncio
 async def test_get_berry_stats_with_cache():
+    """
+    Test the `get_berry_stats` function when berry data is fetched from cache.
+
+    This test mocks the cache to simulate a scenario where berry statistics are retrieved from the cache.
+    It ensures that:
+    - The function returns the cached data directly without calling `fetch_all_berries`.
+    - The returned statistics match the cached data.
+    """
     cached_stats = {
         "berries_names": ["cached_cheri"],
         "min_growth_time": 1,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,15 +1,29 @@
 import time
-from app.cache.cache_handler import cache
-from cachetools import TTLCache
+from unittest.mock import patch
+from app.cache.cache_handler import RedisCacheHandler
 
 def test_cache_set_and_get():
-    cache['test_key'] = 'test_value'
-    assert cache['test_key'] == 'test_value'
+    with patch('app.cache.cache_handler.RedisCacheHandler.set') as mock_set, \
+        patch('app.cache.cache_handler.RedisCacheHandler.get', return_value='test_value'):
+            
+        cache_handler = RedisCacheHandler()
+        cache_handler.set('test_key', 'test_value')
+        
+        result = cache_handler.get('test_key')
+        
+        mock_set.assert_called_once_with('test_key', 'test_value')
+        assert result == 'test_value'
 
 def test_cache_expiry():
-    test_cache = TTLCache(maxsize=100, ttl=1)
-    
-    test_cache['expiring_key'] = 'will_expire'
-    time.sleep(2)
-    
-    assert 'expiring_key' not in test_cache
+    with patch('app.cache.cache_handler.RedisCacheHandler.set') as mock_set, \
+        patch('app.cache.cache_handler.RedisCacheHandler.get', side_effect=[None]):
+            
+        cache_handler = RedisCacheHandler()
+        cache_handler.set('expiring_key', 'will_expire')
+        
+        time.sleep(2)
+        
+        result = cache_handler.get('expiring_key')
+        
+        mock_set.assert_called_once_with('expiring_key', 'will_expire')
+        assert result is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,8 +1,17 @@
+# -*- coding: utf-8 -*-
 import time
 from unittest.mock import patch
 from app.cache.cache_handler import RedisCacheHandler
 
 def test_cache_set_and_get():
+    """
+    Test the `set` and `get` methods of the RedisCacheHandler.
+
+    This test ensures that:
+    - The `set` method stores a key-value pair correctly.
+    - The `get` method retrieves the value associated with the key.
+    - Mocks are used to simulate cache interactions without actual Redis connections.
+    """
     with patch('app.cache.cache_handler.RedisCacheHandler.set') as mock_set, \
         patch('app.cache.cache_handler.RedisCacheHandler.get', return_value='test_value'):
             
@@ -15,6 +24,14 @@ def test_cache_set_and_get():
         assert result == 'test_value'
 
 def test_cache_expiry():
+    """
+    Test the cache expiration behavior of the RedisCacheHandler.
+
+    This test ensures that:
+    - The `set` method stores a key-value pair correctly.
+    - The `get` method returns `None` after the simulated cache expiration period.
+    - Mocks are used to simulate cache interactions and control expiration behavior without an actual Redis connection.
+    """
     with patch('app.cache.cache_handler.RedisCacheHandler.set') as mock_set, \
         patch('app.cache.cache_handler.RedisCacheHandler.get', side_effect=[None]):
             

--- a/tests/test_pokeapi_provider.py
+++ b/tests/test_pokeapi_provider.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 import requests
 from unittest.mock import patch
@@ -5,6 +6,14 @@ from app.data_providers.pokeapi_provider import fetch_all_berries
 
 @pytest.mark.asyncio
 async def test_fetch_all_berries_valid():
+    """
+    Test the `fetch_all_berries` function with valid data.
+
+    This test simulates the behavior of fetching berries from the PokeAPI by:
+    - Mocking the `requests.get` method to return a valid response with berry details.
+    - Ensuring that the returned berry list contains the correct name and growth time.
+    - Verifying that the correct number of berries is returned.
+    """
     mock_response = {'results': [{'name': 'cheri', 'url': 'https://pokeapi.co/api/v2/berry/1/'}]}
     mock_berry_detail = {'name': 'cheri', 'growth_time': 3}
     
@@ -19,6 +28,13 @@ async def test_fetch_all_berries_valid():
 
 @pytest.mark.asyncio
 async def test_fetch_all_berries_failure():
+    """
+    Test the `fetch_all_berries` function when the PokeAPI request fails.
+
+    This test simulates a failed request to the PokeAPI by:
+    - Mocking the `requests.get` method to raise a `RequestException`.
+    - Verifying that an empty list of berries is returned when an error occurs.
+    """
     with patch('requests.get', side_effect=requests.exceptions.RequestException):
         berries = await fetch_all_berries()
     


### PR DESCRIPTION
### This PR adds:
- New cache handling using redis instead of in memory cache.
- Refactor tests to handle mocking with redis cache
- Updated berry models to accept nulls.
- Docstrings to all project
- Updated README documentation
- Fix general errors (like using dict instead of models to create or validate responses)