### PR TITLE
Refactor reserved word PORT to APP_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Create a `.env` file in the root directory of your project to store environment 
 ```makefile
 POKEAPI_BERRY_URL=https://pokeapi.co/api/v2/berry/ # URL for resource of pokeapi
 CACHE_TTL=120  # Cache TTL in seconds
-PORT=8080 # To open port 8080
+APP_PORT=8080 # To open port 8080
 REDIS_HOSTNAME=your-redis-hostname # Hostname for connection of redis redis cache service
 REDIS_PORT=your-redis-port # Port for connection of redis redis cache service
 REDIS_PASSWORD=your-redis-pw # Password for connection of redis cache service

--- a/app/main.py
+++ b/app/main.py
@@ -26,5 +26,5 @@ app.include_router(root_router)
 app.include_router(berry_router)
 
 if __name__ == "__main__":
-    port = int(os.getenv("PORT", 8080))
+    port = int(os.getenv("APP_PORT", 8080))
     uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
### This PR adds:
- Refactor version of env var named PORT to APP_PORT because of reserved words conflicts in Cloud Run.